### PR TITLE
bugfix - average rating static

### DIFF
--- a/src/CommunityStore/Review/Review.php
+++ b/src/CommunityStore/Review/Review.php
@@ -214,18 +214,18 @@ class Review
       return $averageRating / count($ratings);
     }
 
-    public function getAverageRatingOfProduct($product) {
+    public static function getAverageRatingOfProduct($product) {
       $db = \Database::connection();
 
       $status = $db->fetchAssoc("SELECT AVG(rra.rraValue) as avgRating FROM CommunityStoreReviews r
                                 INNER JOIN CommunityStoreReviewRatings rra ON rra.rID = r.rID
                                 WHERE r.pID = ?",
-                                array($product->getProductID()));
+                                array($product->getID()));
 
       return $status['avgRating'];
     }
 
-    public function getAverageApprovedRatingOfProduct($product) {
+    public static function getAverageApprovedRatingOfProduct($product) {
       $db = \Database::connection();
 
       $status = $db->fetchAssoc("SELECT AVG(rra.rraValue) as avgRating FROM CommunityStoreReviews r
@@ -235,7 +235,7 @@ class Review
                                 WHERE r.pID = ? AND rs.rsHandle = ?
                                 AND rsh.rshDate = (SELECT MAX(rsh2.rshDate) FROM CommunityStoreReviewStatusHistories rsh2
                                                   WHERE rsh2.rID = rsh.rID)",
-                                array($product->getProductID(), 'approved'));
+                                array($product->getID(), 'approved'));
 
       return $status['avgRating'];
     }


### PR DESCRIPTION
The function to get the average rating of a product were not static, this fixes that. Also, the function to get the ID from the product object was wrong.
